### PR TITLE
include friend_name

### DIFF
--- a/self_association/index.html
+++ b/self_association/index.html
@@ -153,7 +153,7 @@
         data: {screen: "instructions"}
     }
 
-    timeline.push(instructions)
+   timeline.push(instructions)
 
     // Assignment of label
     var friend_label = {
@@ -166,16 +166,20 @@
             },
         ],
         on_finish: function(data){
+            var stim_list = ['You', 'Stranger']
+            stim_list.push(jsPsych.data.get().last().values()[0]["response"]["Friend"])
+
             jsPsych.data.addProperties({
-                friend_name : data.response["Friend"]
+                friend_name : jsPsych.data.get().last().values()[0]["response"]["Friend"],
+                stim_list: jsPsych.randomization.shuffle(stim_list)
             })
         },
         data: {screen: "friend"},
     }
-    // timeline.push(friend_label)
+    timeline.push(friend_label)
 
     var randomize_shape = jsPsych.randomization.shuffle(['circle', 'triangle', 'square'])
-    var randomize_labels = jsPsych.randomization.shuffle(["You", "Friend", "Stranger"])
+    // var randomize_labels = jsPsych.randomization.shuffle(["You", "Friend", "Stranger"])
     // function get_friend(data){
     //     var friend =jsPsych.data.getLastTrialData().values()[0]["response"]["Friend"]
     //     var all_labels = ['You', 'Stranger']
@@ -191,25 +195,27 @@
     var training = {
         type: jsPsychHtmlButtonResponse,
         stimulus: function(){
-            // var friend =jsPsych.data.getLastTrialData().values()[0]["response"]["Friend"]
-            // var all_labels = ['You', 'Stranger']
-            // all_labels.push(friend)
-            // var randomize_labels = get_friend(data)
+            var cur_stim =jsPsych.data.getLastTrialData().values()[0]["stim_list"]
+        //    var randomize_labels = ['You', 'Stranger']
+        //    randomize_labels.push(friend)
+        //    jsPsych.randomization.shuffle(randomize_labels)
             var text = "<p><b>Training</b></p>" +
-                "<div id ='align-middle'><b>"+ randomize_labels[0] + "</b> represented by the <b>" + randomize_shape[0] + "</b>" + "<img src= ../utils/demo_" + randomize_shape[0] + ".png height=40></img></div><br>" +
-                "<div id ='align-middle'><b>"+ randomize_labels[1] +"</b> represented by the <b>" + randomize_shape[1] + "</b>" + "<img src = ../utils/demo_" + randomize_shape[1] +".png height=40></img></div><br>" +
-                "<div id = 'align-middle'><b>"+ randomize_labels[2] + "</b> represented by the <b>" + randomize_shape[2] +  "</b>" + "<img src= ../utils/demo_" + randomize_shape[2] + ".png height=40></img></div><br>"
+                "<div id ='align-middle'><b>" + cur_stim[0]+ "</b> will be represented by the <b>" + randomize_shape[0] + "</b>" + "<img src= ../utils/demo_" + randomize_shape[0] + ".png height=40></img></div><br>" +
+                "<div id ='align-middle'><b>" + cur_stim[1]+ "</b> will be represented by the <b>" + randomize_shape[1] + "</b>" + "<img src = ../utils/demo_" + randomize_shape[1] +".png height=40></img></div><br>" +
+                "<div id = 'align-middle'><b>" + cur_stim[2]+ "</b> will be represented by the <b>" + randomize_shape[2] +  "</b>" + "<img src= ../utils/demo_" + randomize_shape[2] + ".png height=40></img></div><br>"
             return text;
         },
         trial_duration: 60*1000,
         choices: ['Got it!'],
         data: {screen: "training"},
         on_finish: function () {
-          //  var randomize_labels = get_friend(data)
+             //  var randomize_labels = get_friend(data)
+            data = jsPsych.data.get().filter({screen: "friend"}).values()[0]
             jsPsych.data.addProperties({
-                qn_1: randomize_labels[0],
-                qn_2: randomize_labels[1],
-                qn_3: randomize_labels[2],
+            //    randomize_labels: data.stimulus['randomize_labels'],
+                qn_1: data.stim_list[0],
+                qn_2: data.stim_list[1],
+                qn_3: data.stim_list[2],
                 answer_1: randomize_shape[0],
                 answer_2: randomize_shape[1],
                 answer_3: randomize_shape[2],
@@ -238,11 +244,18 @@
     }
 
     // Experiment Trials
-    var trials = {
+    var trials ={
         type: jsPsychHtmlKeyboardResponse,
         stimulus: function(){
+            // var friend_label = jsPsych.data.getLastTrialData().values()[0]["friend_name"]
+            // var newstim = stimuli.map(entry => {
+            //     return {...entry, label: entry.label == "Friend" ? friend_label: entry.label};
+            // })
             var rand_stim = jsPsych.timelineVariable('stimulus');
             var rand_labels= jsPsych.timelineVariable('label');
+            if (rand_labels == 'Friend'){
+                rand_labels = jsPsych.data.get().filter({screen: "friend"}).values()[0]["friend_name"]
+            }
             return('<img src='+ rand_stim + ' height=170></img>' +
                 '<p style ="font-size:80px; padding-bottom:70px;">+</p>' +
                 '<p style ="font-size:80px;">'+ rand_labels +'</p>')
@@ -251,7 +264,7 @@
         trial_duration: 100,
         data: jsPsych.timelineVariable("data"),
         on_finish: function(data) {
-           // var last_trial =jsPsych.data.get().last(1).values()[0]
+        // var last_trial =jsPsych.data.get().last(1).values()[0]
             if (jsPsych.pluginAPI.compareKeys(data.shape, data.answer_1)){
                 if  (jsPsych.pluginAPI.compareKeys(data.label_cond, data.qn_1)){
                     data.match ="a"
@@ -419,7 +432,6 @@
 
 
     timeline.push(block)
-    timeline.push(block_debrief)
 
 
     /* ----------------- Run the timeline ----------------- */


### PR DESCRIPTION
Hiiii, 

I was looking at this self-association task again after some time and re-reading the original task it was based on. In the original paper, they asked participants to name their best friend and keep them in mind before administering so that the word 'friend' has a closer psychological distance I'd guess. So to make this task more personal, I think we can ask participants to do the same and have their friend's name be a part of the stimuli instead of just having the word 'Friend' appear. I made some tweaks to the task to try it out and it seems to work fine. Lemme know what you think~